### PR TITLE
Added file selection support

### DIFF
--- a/L2DFileDialog/src/L2DFileDialog.h
+++ b/L2DFileDialog/src/L2DFileDialog.h
@@ -41,8 +41,24 @@ namespace FileDialog {
 	};
 
 	static bool fileDialogOpen = false;
+	//forward declarations
+	void ShowFileDialog(bool* open, std::filesystem::path& buffer, FileDialogType type = FileDialogType::OpenFile);
+	void ShowFileDialog(bool* open, std::string& buffer, FileDialogType type = FileDialogType::OpenFile);
 
-	void ShowFileDialog(bool* open, std::filesystem::path& buffer, FileDialogType type = FileDialogType::OpenFile) {
+	//backwards compatibility
+	void ShowFileDialog(bool* open, char* buffer, unsigned int bufferSize, FileDialogType type = FileDialogType::OpenFile) {
+		std::filesystem::path path;
+		ShowFileDialog(open, path, type);
+
+		int path_length = path.generic_string().size();
+		auto wstr = path.generic_string();
+		if (path_length < bufferSize)
+			std::memcpy(buffer, &wstr[0], sizeof(wchar_t)*path_length + 1);
+
+	}
+
+
+	void ShowFileDialog(bool* open, std::filesystem::path& buffer, FileDialogType type) {
 		static int fileDialogFileSelectIndex = 0;
 		static int fileDialogFolderSelectIndex = 0;
 		static std::filesystem::path fileDialogCurrentPath = std::filesystem::current_path();
@@ -325,7 +341,7 @@ namespace FileDialog {
 		}
 	}
 
-	void ShowFileDialog(bool* open, std::string& buffer, FileDialogType type = FileDialogType::OpenFile) {
+	void ShowFileDialog(bool* open, std::string& buffer, FileDialogType type) {
 		std::filesystem::path path;
 		ShowFileDialog(open, path, type);
 		buffer=path.generic_string();


### PR DESCRIPTION
Besides adding ability to select files, I've made some changes:
- changed function signature to simpler one which can takes in reference to std::filesystem::path (or std::string overload). I've added backwards compatibility so current code should still work.
- used more of filesystem library functions (for example `/` - append operator, which automatically adds default folder separator.